### PR TITLE
Auto-detect request fields in msg2dict

### DIFF
--- a/sea/servicer.py
+++ b/sea/servicer.py
@@ -27,5 +27,13 @@ class ServicerMeta(type):
         return super().__new__(cls, name, bases, _kws)
 
 
-def msg2dict(msg, keys):
-    return {k: getattr(msg, k) for k in keys}
+def msg2dict(msg, keys=None):
+    if keys is not None:
+        return {k: getattr(msg, k) for k in keys}
+
+    return {k.name: v
+            for k, v in msg.ListFields()}
+
+
+def stream2dict(stream):
+    yield from map(msg2dict, stream)

--- a/tests/test_servicer.py
+++ b/tests/test_servicer.py
@@ -1,8 +1,9 @@
 import grpc
 
-from sea.servicer import ServicerMeta, msg2dict
+from sea.servicer import ServicerMeta, msg2dict, stream2dict
 from sea import exceptions
 from sea.pb2 import default_pb2
+from tests.wd.protos import helloworld_pb2
 
 
 def test_meta_servicer(app, logstream):
@@ -53,3 +54,17 @@ def test_msg2dict(app):
     app.msg = 'v-msg'
     ret = msg2dict(app, ['name', 'msg', 'tz'])
     assert ret == {'name': 'v-name', 'msg': 'v-msg', 'tz': 'UTC'}
+
+    request = helloworld_pb2.HelloRequest(name="value")
+    ret = msg2dict(request)
+    assert ret == {"name": "value"}
+
+
+def test_stream2dict():
+    def stream_generator():
+        for i in range(5):
+            yield helloworld_pb2.HelloRequest(name=str(i))
+
+    ret = stream2dict(stream_generator())
+    for i, part in enumerate(ret):
+        assert part == {"name": str(i)}


### PR DESCRIPTION
* Auto-detect fields in request when msg2dict doesn't providing parameter `keys`
* Add stream2dict function to convert each request in a stream to a dict