### PR TITLE
fix command line error and cache property race condition problem

### DIFF
--- a/sea/app.py
+++ b/sea/app.py
@@ -44,7 +44,7 @@ class BaseApp:
         self._extensions = {}
         self._middlewares = []
 
-    @utils.cached_property
+    @utils.cached_property_ts
     def logger(self):
         logger = logging.getLogger('sea.app')
         if self.debug and logger.level == logging.NOTSET:
@@ -55,19 +55,19 @@ class BaseApp:
             logger.addHandler(h)
         return logger
 
-    @utils.cached_property
+    @utils.cached_property_ts
     def servicers(self):
         rv = ConstantsObject(self._servicers)
         del self._servicers
         return rv
 
-    @utils.cached_property
+    @utils.cached_property_ts
     def extensions(self):
         rv = ConstantsObject(self._extensions)
         del self._extensions
         return rv
 
-    @utils.cached_property
+    @utils.cached_property_ts
     def middlewares(self):
         rv = tuple(self._middlewares)
         del self._middlewares

--- a/sea/app.py
+++ b/sea/app.py
@@ -44,7 +44,7 @@ class BaseApp:
         self._extensions = {}
         self._middlewares = []
 
-    @utils.cached_property_ts
+    @utils.cached_property
     def logger(self):
         logger = logging.getLogger('sea.app')
         if self.debug and logger.level == logging.NOTSET:
@@ -55,19 +55,19 @@ class BaseApp:
             logger.addHandler(h)
         return logger
 
-    @utils.cached_property_ts
+    @utils.cached_property
     def servicers(self):
         rv = ConstantsObject(self._servicers)
         del self._servicers
         return rv
 
-    @utils.cached_property_ts
+    @utils.cached_property
     def extensions(self):
         rv = ConstantsObject(self._extensions)
         del self._extensions
         return rv
 
-    @utils.cached_property_ts
+    @utils.cached_property
     def middlewares(self):
         rv = tuple(self._middlewares)
         del self._middlewares

--- a/sea/cli.py
+++ b/sea/cli.py
@@ -80,7 +80,8 @@ def _build_parser(subparsers):
 
 
 def _run(root):
-    args = sys.argv[1:]
+    # show help message when user run sea command directly
+    args = sys.argv[1:] or ['--help']
     known, argv = root.parse_known_args(args)
     kwargs = vars(known)
     handler = kwargs.pop('handler')

--- a/sea/utils.py
+++ b/sea/utils.py
@@ -1,4 +1,5 @@
 import sys
+from threading import Lock
 
 
 def import_string(import_name):
@@ -20,6 +21,7 @@ def import_string(import_name):
 
 
 class cached_property:
+
     def __init__(self, func, name=None):
         self.func = func
         self.__doc__ = getattr(func, '__doc__')
@@ -30,6 +32,21 @@ class cached_property:
             return self
         res = instance.__dict__[self.name] = self.func(instance)
         return res
+
+
+class cached_property_ts(cached_property):
+    """ thread safe cached property """
+
+    def __init__(self, func, name=None):
+        super().__init__(func, name)
+        self.lock = Lock()
+
+    def __get__(self, instance, cls=None):
+        with self.lock:
+            try:
+                return instance.__dict__[self.name]
+            except KeyError:
+                return super().__get__(instance, cls)
 
 
 class Singleton(type):

--- a/sea/utils.py
+++ b/sea/utils.py
@@ -21,32 +21,23 @@ def import_string(import_name):
 
 
 class cached_property:
+    """ thread safe cached property """
 
     def __init__(self, func, name=None):
         self.func = func
         self.__doc__ = getattr(func, '__doc__')
         self.name = name or func.__name__
-
-    def __get__(self, instance, cls=None):
-        if instance is None:
-            return self
-        res = instance.__dict__[self.name] = self.func(instance)
-        return res
-
-
-class cached_property_ts(cached_property):
-    """ thread safe cached property """
-
-    def __init__(self, func, name=None):
-        super().__init__(func, name)
         self.lock = Lock()
 
     def __get__(self, instance, cls=None):
         with self.lock:
+            if instance is None:
+                return self
             try:
                 return instance.__dict__[self.name]
             except KeyError:
-                return super().__get__(instance, cls)
+                res = instance.__dict__[self.name] = self.func(instance)
+                return res
 
 
 class Singleton(type):

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -103,3 +103,7 @@ def test_main():
     sys.argv = 'sea -h'.split()
     with pytest.raises(SystemExit):
         cli.main()
+    # no arguments scenes
+    sys.argv = ['sea']
+    with pytest.raises(SystemExit):
+        cli.main()


### PR DESCRIPTION
This PR fix two problems.

- I found that running `sea` command directly will raise error
```Bash
$ sea
Traceback (most recent call last):
  File "/home/ubuntu/PY35/bin/sea", line 11, in <module>
    load_entry_point('sea==0.9.6', 'console_scripts', 'sea')()
  File "/home/ubuntu/PY35/lib/python3.5/site-packages/sea/cli.py", line 106, in main
    return _run(root)
  File "/home/ubuntu/PY35/lib/python3.5/site-packages/sea/cli.py", line 86, in _run
    handler = kwargs.pop('handler')
KeyError: 'handler'
```
- there will be a race condition problem in origin `app.py` https://github.com/shanbay/sea/blob/master/sea/app.py#L58

```Python
    @utils.cached_property
    def servicers(self):
        # thread 1 pause here
        rv = ConstantsObject(self._servicers) 
        del self._servicers
        return rv
```

Maybe there will be two threads in servicers and enter this function, But thread 1 pause and thread 2 run the whole function. Then thread 1 resume, it will raise `AttributeError` because the `self._servicers` has been delete by thread 2.