### PR TITLE
fix bootstrap output info

### DIFF
--- a/sea/cmds.py
+++ b/sea/cmds.py
@@ -111,7 +111,7 @@ def new(project, **extra):
                     else:
                         shutil.copyfile(src, dst)
 
-                    print('created: {}'.format(dst))
+                    print('created: {}'.format(r if ext == '.tmpl' else dst))
 
     path = os.path.join(os.getcwd(), project)
     if os.path.exists(path):

--- a/sea/datatypes.py
+++ b/sea/datatypes.py
@@ -66,3 +66,6 @@ class ConstantsObject(ImmutableDict):
 
     def __dir__(self):
         return self.keys()
+
+    def __setattr__(self, name, val):
+        is_immutable(self)

--- a/sea/local.py
+++ b/sea/local.py
@@ -21,7 +21,7 @@ def _default_cls_attr(name, type_, cls_value):
     })
 
 
-class Proxy(object):
+class Proxy:
     """Proxy to another object."""
 
     # Code stolen from werkzeug.local.Proxy.


### PR DESCRIPTION
when using command `sea new <app>` something like  `created  <pwd>/<app>/servicers.py.tmpl` will appear on screen, however, the `tmpl` should not be included