### PR TITLE
Allow sea generate run without app loaded

### DIFF
--- a/sea/cmds.py
+++ b/sea/cmds.py
@@ -30,7 +30,7 @@ def console():
     return 0
 
 
-@jobm.job('generate', aliases=['g'], help='Generate RPC')
+@jobm.job('generate', aliases=['g'], inapp=False, help='Generate RPC')
 @jobm.option('-I', '--proto_path', required=True, action='append',
              help="the dir in which we'll search the proto files")
 @jobm.option('protos', nargs='+',
@@ -39,7 +39,8 @@ def console():
 def generate(proto_path, protos):
     from grpc_tools import protoc
     well_known_path = os.path.join(os.path.dirname(protoc.__file__), '_proto')
-    proto_out = os.path.join(current_app.root_path, 'protos')
+
+    proto_out = os.path.join(os.getcwd(), 'protos')
     proto_path.append(well_known_path)
     proto_path_args = []
     for protop in proto_path:

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -22,15 +22,16 @@ def test_cmd_console(app):
         assert mocked.embed.called
 
 
-def test_cmd_generate(app):
+def test_cmd_generate():
     sys.argv = ('sea g -I /path/to/protos -I /another/path/to/protos '
                 'hello.proto test.proto').split()
+
     with mock.patch('grpc_tools.protoc.main', return_value=0) as mocked:
         assert cli.main() == 0
         import grpc_tools
-        well_known_path = os.path.join(os.path.dirname(grpc_tools.__file__),
-                                       '_proto')
-        proto_out = os.path.join(app.root_path, 'protos')
+        well_known_path = os.path.join(
+            os.path.dirname(grpc_tools.__file__), '_proto')
+        proto_out = os.path.join(os.getcwd(), 'protos')
         cmd = [
             'grpc_tools.protoc',
             '--proto_path', '/path/to/protos',


### PR DESCRIPTION
Sometimes grpc `pb2` modules may be ruined in a conflict during `git merge`,  causing `sea generate` crashes because of `SyntaxError` during app loading.  
So I make the `generate` command run without app loaded. The command will load app only when directory `./protos` not exists.