### PR TITLE
Make README on PyPI more readable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     version=version,
     description='shanbay rpc framework',
     long_description=readme,
+    long_description_content_type='text/markdown',
     url='https://github.com/shanbay/sea',
     author='Michael Ding',
     author_email='yandy.ding@gmail.com',


### PR DESCRIPTION
Add `long_description_content_type` argument to tell PyPI to render the README as Markdown.