### PR TITLE
inspect时不create_app

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,7 +10,8 @@ engines:
     enabled: true
     config:
       languages:
-      - python
+        python:
+          count_threshold: 3
 ratings:
   paths:
   - "**.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - pip install -r test-requirements.txt -U
 script:
 - flake8 sea --exclude=*_pb2.py
-- pytest tests/test_contrib/test_extensions/test_celery.py::test_celery_no_app --cov-fail-under=30
+- pytest tests/test_contrib/test_extensions/test_celery.py::test_celery_no_app --cov-fail-under=10
 - pytest tests
 after_success:
 - CODECLIMATE_REPO_TOKEN=19c5e18e184070a726bb6fc703e321e526ca638df16f9623654044bcccdb1a9d

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 - pip install -r test-requirements.txt -U
 script:
 - flake8 sea --exclude=*_pb2.py
+- pytest tests/test_contrib/test_extensions/test_celery.py::test_celery_no_app --cov-fail-under=30
 - pytest tests
 after_success:
 - CODECLIMATE_REPO_TOKEN=19c5e18e184070a726bb6fc703e321e526ca638df16f9623654044bcccdb1a9d

--- a/sea/contrib/extensions/celery/cmd.py
+++ b/sea/contrib/extensions/celery/cmd.py
@@ -14,7 +14,8 @@ def celery(argv, app):
         config = importlib.import_module('configs.{}'.format(config_name))
         extensions = importlib.import_module("app.extensions")
         celeryapp = getattr(extensions, app)
-        celeryapp.config_from_object(config, namespace=f"{app}_".upper())
+        celeryapp.config_from_object(
+            config, namespace="{}_".format(app).upper())
     else:
         create_app()
     sys.argv = (

--- a/sea/contrib/extensions/celery/cmd.py
+++ b/sea/contrib/extensions/celery/cmd.py
@@ -3,24 +3,28 @@ import sys
 
 from celery.__main__ import main as celerymain
 
-from sea.cli import jobm
 from sea import create_app
+from sea.cli import jobm
+from sea.utils import import_string
 
 
 def celery(argv, app):
     if argv[0] == "inspect":
-        import importlib
         config_name = os.environ.get("SEA_ENV")
-        config = importlib.import_module('configs.{}'.format(config_name))
-        extensions = importlib.import_module("app.extensions")
-        celeryapp = getattr(extensions, app)
+        config = import_string('configs.{}'.format(config_name))
+        celeryapp = import_string(
+            "sea.contrib.extensions.celery.empty_celeryapp.capp")
         celeryapp.config_from_object(
             config, namespace="{}_".format(app).upper())
+        sys.argv = (
+            ["celery"] + argv + ["-A",
+                                 "sea.contrib.extensions.celery.empty_celeryapp.capp".format(app=app)]
+        )
     else:
         create_app()
-    sys.argv = (
-        ["celery"] + argv + ["-A", "app.extensions:{app}".format(app=app)]
-    )
+        sys.argv = (
+            ["celery"] + argv + ["-A", "app.extensions:{app}".format(app=app)]
+        )
     return celerymain()
 
 

--- a/sea/contrib/extensions/celery/cmd.py
+++ b/sea/contrib/extensions/celery/cmd.py
@@ -1,22 +1,34 @@
+import os
 import sys
 
 from celery.__main__ import main as celerymain
 
 from sea.cli import jobm
+from sea import create_app
 
 
 def celery(argv, app):
+    if argv[0] == "inspect":
+        import importlib
+        config_name = os.environ.get("SEA_ENV")
+        config = importlib.import_module('configs.{}'.format(config_name))
+        extensions = importlib.import_module("app.extensions")
+        celeryapp = getattr(extensions, app)
+        celeryapp.config_from_object(config, namespace=f"{app}_".upper())
+    else:
+        create_app()
     sys.argv = (
         ["celery"] + argv + ["-A", "app.extensions:{app}".format(app=app)]
     )
     return celerymain()
 
 
-@jobm.job("async_task", proxy=True, help="invoke celery cmds for async tasks")
+@jobm.job("async_task", proxy=True, inapp=False,
+          help="invoke celery cmds for async tasks")
 def async_task(argv):
     return celery(argv, "async_task")
 
 
-@jobm.job("bus", proxy=True, help="invoke celery cmds for bus")
+@jobm.job("bus", proxy=True, inapp=False, help="invoke celery cmds for bus")
 def bus(argv):
     return celery(argv, "bus")

--- a/sea/contrib/extensions/celery/cmd.py
+++ b/sea/contrib/extensions/celery/cmd.py
@@ -1,24 +1,18 @@
-import os
 import sys
 
 from celery.__main__ import main as celerymain
 
 from sea import create_app
 from sea.cli import jobm
-from sea.utils import import_string
 
 
 def celery(argv, app):
     if argv[0] == "inspect":
-        config_name = os.environ.get("SEA_ENV")
-        config = import_string('configs.{}'.format(config_name))
-        celeryapp = import_string(
-            "sea.contrib.extensions.celery.empty_celeryapp.capp")
-        celeryapp.config_from_object(
-            config, namespace="{}_".format(app).upper())
+        from sea.contrib.extensions.celery import empty_celeryapp
+        empty_celeryapp.load_config(app)
         sys.argv = (
-            ["celery"] + argv + ["-A",
-                                 "sea.contrib.extensions.celery.empty_celeryapp.capp".format(app=app)]
+            ["celery"] + argv
+            + ["-A", "sea.contrib.extensions.celery.empty_celeryapp.capp"]
         )
     else:
         create_app()

--- a/sea/contrib/extensions/celery/empty_celeryapp.py
+++ b/sea/contrib/extensions/celery/empty_celeryapp.py
@@ -1,4 +1,14 @@
+import os
+from sea.utils import import_string
 from celery import Celery
 
 
 capp = Celery()
+
+
+def load_config(app, without_imports=True):
+    config_name = os.environ.get("SEA_ENV")
+    config = import_string('configs.{}'.format(config_name))
+    capp.config_from_object(config, namespace="{}_".format(app).upper())
+    if without_imports:
+        capp._conf["{}_imports".format(app).upper()] = []

--- a/sea/contrib/extensions/celery/empty_celeryapp.py
+++ b/sea/contrib/extensions/celery/empty_celeryapp.py
@@ -1,0 +1,4 @@
+from celery import Celery
+
+
+capp = Celery()

--- a/tests/test_contrib/test_extensions/test_celery.py
+++ b/tests/test_contrib/test_extensions/test_celery.py
@@ -1,4 +1,7 @@
+import os
+import sys
 import mock
+import importlib
 from sea.contrib.extensions.celery import AsyncTask, Bus
 from sea.contrib.extensions.celery.cmd import async_task, bus
 
@@ -10,3 +13,28 @@ def test_celery(app):
         async_task(["worker"])
         bus(["worker"])
     # assert c.conf.broker_url == 'redis://localhost:6379/2'
+
+
+def test_celery_no_app():
+    """需要独立于其他测试的session单独跑一次"""
+    root_path = os.path.join(os.path.dirname(__file__).replace(
+        '/test_contrib/test_extensions', ''), 'wd')
+
+    if root_path not in sys.path:
+        """单独跑"""
+        os.environ.setdefault('SEA_ENV', 'testing')
+        sys.path.append(root_path)
+        extensions = importlib.import_module("app.extensions")
+        celeryapp = extensions.async_task
+        assert celeryapp.conf["broker_url"] is None
+    else:
+        """一起跑（app.extensions已经被初始化）"""
+        extensions = importlib.import_module("app.extensions")
+        celeryapp = extensions.async_task
+        assert celeryapp.conf["broker_url"] == 'redis://localhost:6379/2'
+
+    with mock.patch("sea.contrib.extensions.celery.cmd.celerymain") as mocked:
+        async_task("inspect ping -d wd@$HOSTNAME".split())
+        assert mocked.called
+    assert celeryapp.conf["broker_url"] == "redis://localhost:6379/2"
+    assert celeryapp.conf["TASK_DEFAULT_QUEUE"] == "wd.celery"

--- a/tests/test_contrib/test_extensions/test_celery.py
+++ b/tests/test_contrib/test_extensions/test_celery.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import mock
-import importlib
+from sea import import_string
 from sea.contrib.extensions.celery import AsyncTask, Bus
 from sea.contrib.extensions.celery.cmd import async_task, bus
 
@@ -24,14 +24,9 @@ def test_celery_no_app():
         """单独跑"""
         os.environ.setdefault('SEA_ENV', 'testing')
         sys.path.append(root_path)
-        extensions = importlib.import_module("app.extensions")
-        celeryapp = extensions.async_task
-        assert celeryapp.conf["broker_url"] is None
-    else:
-        """一起跑（app.extensions已经被初始化）"""
-        extensions = importlib.import_module("app.extensions")
-        celeryapp = extensions.async_task
-        assert celeryapp.conf["broker_url"] == 'redis://localhost:6379/2'
+    celeryapp = import_string(
+        "sea.contrib.extensions.celery.empty_celeryapp.capp")
+    assert celeryapp.conf["broker_url"] is None
 
     with mock.patch("sea.contrib.extensions.celery.cmd.celerymain") as mocked:
         async_task("inspect ping -d wd@$HOSTNAME".split())

--- a/tests/test_contrib/test_extensions/test_celery.py
+++ b/tests/test_contrib/test_extensions/test_celery.py
@@ -33,3 +33,6 @@ def test_celery_no_app():
         assert mocked.called
     assert celeryapp.conf["broker_url"] == "redis://localhost:6379/2"
     assert celeryapp.conf["TASK_DEFAULT_QUEUE"] == "wd.celery"
+    assert celeryapp.conf["imports"] == []
+    assert celeryapp.conf["IMPORTS"] == []
+    assert celeryapp.conf["async_task_imports".upper()] == []


### PR DESCRIPTION
使用`sea celery inspect`命令（健康检查会用到）时，不去create_app，而是按照已有的约定读取配置，初始化app.extensions里的async_task或bus。

可以节省每次心跳时create_app、init extensions的开销，同时防止因为自己做的extension.init_app里有非幂等的逻辑被反复调用。
