### PR TITLE
fix ipython color

### DIFF
--- a/sea/cmds.py
+++ b/sea/cmds.py
@@ -22,7 +22,7 @@ def console():
     ctx = {'app': current_app}
     try:
         from IPython import embed
-        h, kwargs = embed, dict(banner1=banner, user_ns=ctx)
+        h, kwargs = embed, dict(banner1=banner, user_ns=ctx, colors="neutral")
     except ImportError:
         import code
         h, kwargs = code.interact, dict(banner=banner, local=ctx)


### PR DESCRIPTION
文档写的默认是 neutral
https://ipython.readthedocs.io/en/stable/config/details.html#terminal-colors

然而在ipython 7里面会没有颜色，手动指定之后好了
https://github.com/ipython/ipython/issues/11523