### PR TITLE
修复 windows 平台 sea new 会报错的问题

### DIFF
--- a/sea/cmds.py
+++ b/sea/cmds.py
@@ -108,6 +108,7 @@ def new(project, **extra):
                 src = os.path.join(dirpath, fn)
                 if src not in skip:
                     relfn = os.path.relpath(src, TMPLPATH)
+                    relfn = relfn.replace(os.path.sep, '/')
                     dst = os.path.join(path, relfn)
                     # create the parentdir if not exists
                     os.makedirs(os.path.dirname(dst), exist_ok=True)


### PR DESCRIPTION
原报错信息：

```
Traceback (most recent call last):
  File "C:\Users\liriansu\.virtualenvs\poseidon-tt7N4OpO\Scripts\sea-script.py", line 11, in <module>
    load_entry_point('sea==2.2.0', 'console_scripts', 'sea')()
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\sea-2.2.0-py3.8.egg\sea\cli.py", line 113, in main
    return _run(root)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\sea-2.2.0-py3.8.egg\sea\cli.py", line 100, in _run
    return handler(**kwargs)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\sea-2.2.0-py3.8.egg\sea\cmds.py", line 129, in new
    _gen_project(path, skip=_build_skip_files(extra), ctx=ctx)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\sea-2.2.0-py3.8.egg\sea\cmds.py", line 117, in _gen_project
    tmpl = env.get_template(relfn)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\jinja2\environment.py", line 883, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\jinja2\environment.py", line 857, in _load_template
    template = self.loader.load(self, name, globals)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\jinja2\loaders.py", line 115, in load
    source, filename, uptodate = self.get_source(environment, name)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\jinja2\loaders.py", line 177, in get_source
    pieces = split_template_path(template)
  File "c:\users\liriansu\.virtualenvs\poseidon-tt7n4opo\lib\site-packages\jinja2\loaders.py", line 32, in split_template_path
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: app\async_tasks.py.tmpl
```

因为在 [`jinja2/loaders.py`](https://github.com/pallets/jinja/blob/master/src/jinja2/loaders.py#L24) 中使用的是 `/` 分隔符，windows 上用的是 `\` 分隔符。
而 jinja 的哲学是统一都 replace 为 `/`……（这个风格不一定对，但他的项目 api 都这样）

所以我们调用的时候先修一下 :)

closes #132 