### PR TITLE
修复 Windows 平台 sea server 会报错的问题

### DIFF
--- a/sea/server.py
+++ b/sea/server.py
@@ -1,7 +1,9 @@
+import logging
+import os
 import signal
 import time
-import logging
 from concurrent import futures
+
 import grpc
 
 from sea import signals
@@ -53,9 +55,10 @@ class Server:
 
     def register_signal(self):
         signal.signal(signal.SIGINT, self._stop_handler)
-        signal.signal(signal.SIGHUP, self._stop_handler)
         signal.signal(signal.SIGTERM, self._stop_handler)
-        signal.signal(signal.SIGQUIT, self._stop_handler)
+        if os.sys.platform != 'win32':
+            signal.signal(signal.SIGHUP, self._stop_handler)
+            signal.signal(signal.SIGQUIT, self._stop_handler)
 
     def _stop_handler(self, signum, frame):
         grace = self.app.config['GRPC_GRACE']


### PR DESCRIPTION
原因：windows 平台没有 SIGHUP/SIGQUIT

参见：https://docs.python.org/3/library/signal.html