### PR TITLE
feat: support middlewares from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## [Unreleased] - 2023-08-21
+## [3.1.2] - 2024-12-18
+### Added
+- Support reading grpc middlewares from env and removing duplicates according to config middlewares
+
+## [3.1.1] - 2023-08-21
 ### Added
 - Support grpc reflection
 

--- a/sea/app.py
+++ b/sea/app.py
@@ -127,7 +127,10 @@ class BaseApp:
         self._extensions[name] = ext
 
     def load_middlewares(self):
-        mids = ["sea.middleware.GuardMiddleware"] + self.config.get("MIDDLEWARES")
+        config_mids = self.config.get("MIDDLEWARES")
+        mids_from_env = os.environ.get("SEA_MIDDLEWARES", "").split(",")
+        env_mids = [mid for mid in mids_from_env if mid and mid not in config_mids]
+        mids = ["sea.middleware.GuardMiddleware"] + env_mids + config_mids
         for mn in mids:
             m = utils.import_string(mn)
             self._middlewares.insert(0, m)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,9 +29,10 @@ def test_baseapp(caplog):
     assert _app.config["PORT"] == 4001
     assert _app.debug
     assert _app.testing
+    os.environ["SEA_MIDDLEWARES"] = "sea.middleware.BaseMiddleware,sea.middleware.ServiceLogMiddleware,"
     _app.load_middlewares()
 
-    assert len(_app.middlewares) == 3
+    assert len(_app.middlewares) == 4
 
     with mock.patch('sea._app', new=_app):
         from app import extensions, servicers


### PR DESCRIPTION
在一些场景下 我们希望可以通过环境变量向项目中安装一些业务无关的中间件 如 tracing 等 因此在加载 middleware 时尝试从 env 中读取 middleware 字符串并写入 middlewares 数组