### PR TITLE
fix: 'install_requires' must be a string or list of strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --index-url=https://mirrors.aliyun.com/pypi/simple --output-file=requirements.txt requirements.in
 #
---index-url https://mirrors.aliyun.com/pypi/simple
 
 blinker==1.6.2
     # via -r requirements.in


### PR DESCRIPTION
error in sea setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected package name at the start of dependency specifier 去除注释以满足 pip 要求